### PR TITLE
Migrate clojure functionality from legacy iron.nvim

### DIFF
--- a/lua/trex/fts/clojure.lua
+++ b/lua/trex/fts/clojure.lua
@@ -3,7 +3,7 @@ local nvim = vim.api
 local utils = {}
 
 utils.get_ns = function()
-  nvim.nvim_feedkeys("mxggf w\"sy$`x", "x", "")
+  nvim.nvim_feedkeys("mxggf w\"syw`x", "x", "")
   cmd_out = nvim.nvim_eval("@s")
 
   return cmd_out

--- a/lua/trex/fts/clojure.lua
+++ b/lua/trex/fts/clojure.lua
@@ -1,0 +1,61 @@
+local iron = require("iron")
+local nvim = vim.api
+local utils = {}
+
+utils.get_ns = function()
+  -- TODO silent normal!
+  nvim.nvim_feedkeys("mxggf w\"sy$`x", "", "")
+  cmd_out = nvim.nvim_eval("@s")
+
+  return cmd_out
+end
+
+utils.get_current_parens = function()
+  -- TODO silent normal!
+  nvim.nvim_feedkeys("mx%\"sy%`x", "", "")
+  cmd_out = nvim.nvim_eval("@s")
+
+  return cmd_out
+end
+
+
+local clojure = {}
+
+clojure.require_ns = function()
+  nvim.nvim_feedkeys("mx%\"sy%`x", "", "")
+  cmd_out = nvim.nvim_eval("@s")
+
+  data = "(require '" .. cmd_out .. ")"
+  iron.ll.send_to_repl("clojure", data)
+  return
+end
+
+clojure.switch_ns = function()
+  data = "(in-ns '" .. utils.get_ns() .. ")"
+  iron.ll.send_to_repl("clojure", data)
+  return
+end
+
+clojure.lein_require = function()
+  data = "(require '" .. utils.get_current_parens() .. ")"
+  iron.ll.send_to_repl("clojure", data)
+  return
+end
+
+clojure.lein_import = function()
+    data = "(import '" .. utils.get_current_parens() .. ")"
+  iron.ll.send_to_repl("clojure", data)
+  return
+end
+
+return clojure
+
+
+    -- ('<leader>sr', 'require-file', lein_require_file),
+    -- ('<leader>sR', 'require-with-ns', lein_require_with_ns),
+    -- ('<leader>s.', 'prompt-require', lein_prompt_require),
+    -- ('<leader>s/', 'prompt-require-as', lein_prompt_require_as),
+    -- ('<leader>ss', 'send-block', lein_send),
+
+    -- ('<leader>mf', 'midje-load-facts', midje_load_facts),
+    -- ('<leader>ma', 'midje-autotest', midje_autotest),

--- a/lua/trex/fts/clojure.lua
+++ b/lua/trex/fts/clojure.lua
@@ -79,4 +79,10 @@ clojure.lein_send_visual = function()
   return
 end
 
+clojure.test_current_file = function()
+  data = "(clojure.test/run-tests '" .. utils.get_ns() .. ")"
+  iron.ll.send_to_repl("clojure", data)
+  return
+end
+
 return clojure

--- a/lua/trex/fts/clojure.lua
+++ b/lua/trex/fts/clojure.lua
@@ -18,6 +18,21 @@ utils.get_current_parens = function()
   return cmd_out
 end
 
+utils.get_outer_parens = function()
+  nvim.nvim_feedkeys("mx?^(\\"sya(`x'", "", "")
+  nvim.nvim_command("nohl")
+
+  cmd_out = nvim.nvim_eval("@s")
+  return cmd_out
+end
+
+utils.get_visual = function()
+  nvim.nvim_feedkeys("gv\"sy", "", "")
+
+  cmd_out = nvim.nvim_eval("@s")
+  return cmd_out
+end
+
 
 local clojure = {}
 
@@ -42,20 +57,28 @@ clojure.lein_require = function()
   return
 end
 
+clojure.lein_require_current_file = function()
+  data = "(require '" .. utils.get_ns() .. " :reload)"
+  iron.ll.send_to_repl("clojure", data)
+  return
+end
+
 clojure.lein_import = function()
-    data = "(import '" .. utils.get_current_parens() .. ")"
+  data = "(import '" .. utils.get_current_parens() .. ")"
+  iron.ll.send_to_repl("clojure", data)
+  return
+end
+
+clojure.lein_send = function()
+  data = utils.get_outer_parens()
+  iron.ll.send_to_repl("clojure", data)
+  return
+end
+
+clojure.lein_send_visual = function()
+  data = utils.get_visual()
   iron.ll.send_to_repl("clojure", data)
   return
 end
 
 return clojure
-
-
-    -- ('<leader>sr', 'require-file', lein_require_file),
-    -- ('<leader>sR', 'require-with-ns', lein_require_with_ns),
-    -- ('<leader>s.', 'prompt-require', lein_prompt_require),
-    -- ('<leader>s/', 'prompt-require-as', lein_prompt_require_as),
-    -- ('<leader>ss', 'send-block', lein_send),
-
-    -- ('<leader>mf', 'midje-load-facts', midje_load_facts),
-    -- ('<leader>ma', 'midje-autotest', midje_autotest),

--- a/lua/trex/fts/clojure.lua
+++ b/lua/trex/fts/clojure.lua
@@ -3,23 +3,21 @@ local nvim = vim.api
 local utils = {}
 
 utils.get_ns = function()
-  -- TODO silent normal!
-  nvim.nvim_feedkeys("mxggf w\"sy$`x", "", "")
+  nvim.nvim_feedkeys("mxggf w\"sy$`x", "x", "")
   cmd_out = nvim.nvim_eval("@s")
 
   return cmd_out
 end
 
 utils.get_current_parens = function()
-  -- TODO silent normal!
-  nvim.nvim_feedkeys("mx%\"sy%`x", "", "")
+  nvim.nvim_feedkeys("mx%\"sy%`x", "x", "")
   cmd_out = nvim.nvim_eval("@s")
 
   return cmd_out
 end
 
 utils.get_outer_parens = function()
-  nvim.nvim_feedkeys("mx?^(\\"sya(`x'", "", "")
+  nvim.nvim_feedkeys("mx?^(\\"sya(`x'", "x", "")
   nvim.nvim_command("nohl")
 
   cmd_out = nvim.nvim_eval("@s")
@@ -27,7 +25,7 @@ utils.get_outer_parens = function()
 end
 
 utils.get_visual = function()
-  nvim.nvim_feedkeys("gv\"sy", "", "")
+  nvim.nvim_feedkeys("gv\"sy", "x", "")
 
   cmd_out = nvim.nvim_eval("@s")
   return cmd_out
@@ -37,7 +35,7 @@ end
 local clojure = {}
 
 clojure.require_ns = function()
-  nvim.nvim_feedkeys("mx%\"sy%`x", "", "")
+  nvim.nvim_feedkeys("mx%\"sy%`x", "x", "")
   cmd_out = nvim.nvim_eval("@s")
 
   data = "(require '" .. cmd_out .. ")"

--- a/lua/trex/fts/clojure.lua
+++ b/lua/trex/fts/clojure.lua
@@ -49,6 +49,12 @@ clojure.switch_ns = function()
   return
 end
 
+clojure.switch_to_user_ns = function()
+  data = "(in-ns 'user)"
+  iron.ll.send_to_repl("clojure", data)
+  return
+end
+
 clojure.lein_require = function()
   data = "(require '" .. utils.get_current_parens() .. ")"
   iron.ll.send_to_repl("clojure", data)

--- a/lua/trex/fts/init.lua
+++ b/lua/trex/fts/init.lua
@@ -1,0 +1,6 @@
+-- luacheck: globals unpack
+
+local fts = {
+  clojure = require("trex.fts.clojure")
+}
+return fts

--- a/lua/trex/init.lua
+++ b/lua/trex/init.lua
@@ -5,7 +5,8 @@ local trex = {
   data = {
     history = {},
     cursor = 0
-  }
+  },
+  fts = require("trex.fts")
 }
 
 trex.ll.bufdata = function()

--- a/plugin/trex.vim
+++ b/plugin/trex.vim
@@ -6,4 +6,9 @@ command! -nargs=? TrexAttach lua require("trex").attach(<f-args>)
 
 autocmd Filetype clojure nmap <buffer> <leader>so :lua require ("trex").fts.clojure.require_ns()<CR>
 autocmd Filetype clojure nmap <buffer> <leader>si :lua require ("trex").fts.clojure.lein_import()<CR>
+autocmd Filetype clojure nmap <buffer> <leader>sr :lua require ("trex").fts.clojure.lein_require_current_file()<CR>
 autocmd Filetype clojure nmap <buffer> <leader>sn :lua require ("trex").fts.clojure.switch_ns()<CR>
+autocmd Filetype clojure nmap <buffer> <leader>ss :lua require ("trex").fts.clojure.lein_send()<CR>
+
+autocmd Filetype clojure vnoremap <buffer> <leader>sv :lua require ("trex").fts.clojure.lein_send_visual()<CR>
+

--- a/plugin/trex.vim
+++ b/plugin/trex.vim
@@ -3,3 +3,7 @@ command! -nargs=0 TrexNext lua require("trex").next()
 command! -nargs=0 TrexPrev lua require("trex").previous()
 command! -nargs=0 TrexInvoke lua require("trex").invoke()
 command! -nargs=? TrexAttach lua require("trex").attach(<f-args>)
+
+autocmd Filetype clojure nmap <buffer> <leader>so :lua require ("trex").fts.clojure.require_ns()<CR>
+autocmd Filetype clojure nmap <buffer> <leader>si :lua require ("trex").fts.clojure.lein_import()<CR>
+autocmd Filetype clojure nmap <buffer> <leader>sn :lua require ("trex").fts.clojure.switch_ns()<CR>

--- a/plugin/trex.vim
+++ b/plugin/trex.vim
@@ -8,6 +8,7 @@ autocmd Filetype clojure nmap <buffer> <leader>so :lua require ("trex").fts.cloj
 autocmd Filetype clojure nmap <buffer> <leader>si :lua require ("trex").fts.clojure.lein_import()<CR>
 autocmd Filetype clojure nmap <buffer> <leader>sr :lua require ("trex").fts.clojure.lein_require_current_file()<CR>
 autocmd Filetype clojure nmap <buffer> <leader>sn :lua require ("trex").fts.clojure.switch_ns()<CR>
+autocmd Filetype clojure nmap <buffer> <leader>su :lua require ("trex").fts.clojure.switch_to_user_ns()<CR>
 autocmd Filetype clojure nmap <buffer> <leader>ss :lua require ("trex").fts.clojure.lein_send()<CR>
 autocmd Filetype clojure nmap <buffer> <leader>st :lua require ("trex").fts.clojure.test_current_file()<CR>
 

--- a/plugin/trex.vim
+++ b/plugin/trex.vim
@@ -9,6 +9,6 @@ autocmd Filetype clojure nmap <buffer> <leader>si :lua require ("trex").fts.cloj
 autocmd Filetype clojure nmap <buffer> <leader>sr :lua require ("trex").fts.clojure.lein_require_current_file()<CR>
 autocmd Filetype clojure nmap <buffer> <leader>sn :lua require ("trex").fts.clojure.switch_ns()<CR>
 autocmd Filetype clojure nmap <buffer> <leader>ss :lua require ("trex").fts.clojure.lein_send()<CR>
+autocmd Filetype clojure nmap <buffer> <leader>st :lua require ("trex").fts.clojure.test_current_file()<CR>
 
 autocmd Filetype clojure vnoremap <buffer> <leader>sv :lua require ("trex").fts.clojure.lein_send_visual()<CR>
-


### PR DESCRIPTION
With the lua rollout for `iron.nvim` (https://github.com/Vigemus/iron.nvim/pull/85) the clojure functionality will be removed. 

It seems like you intend to have that type of functionality moved to `trex.nvim`, so I took a shot at doing the migration.

Note that I know very little about lua or the nvim api, so the code quality may not be the best