### PR TITLE
clojure usage fix: `.fn` was missing and erroring out shortcuts

### DIFF
--- a/lua/trex/fts/clojure.lua
+++ b/lua/trex/fts/clojure.lua
@@ -87,7 +87,7 @@ clojure.fn.lein_send_visual = function()
 end
 
 clojure.fn.test_current_file = function()
-  data = "(clojure.fn.test/run-tests '" .. utils.get_ns() .. ")"
+  data = "(clojure.test/run-tests '" .. utils.get_ns() .. ")"
   iron.ll.send_to_repl("clojure", data)
   return
 end

--- a/plugin/trex.vim
+++ b/plugin/trex.vim
@@ -7,12 +7,12 @@ command! -nargs=0 TrexInvoke lua require("trex").invoke()
 command! -nargs=? TrexAttach lua require("trex").attach(<f-args>)
 
 " TODO Remove in favor of luacmd
-autocmd Filetype clojure nmap <buffer> <leader>so :lua require ("trex").fts.clojure.require_ns()<CR>
-autocmd Filetype clojure nmap <buffer> <leader>si :lua require ("trex").fts.clojure.lein_import()<CR>
-autocmd Filetype clojure nmap <buffer> <leader>sr :lua require ("trex").fts.clojure.lein_require_current_file()<CR>
-autocmd Filetype clojure nmap <buffer> <leader>sn :lua require ("trex").fts.clojure.switch_ns()<CR>
-autocmd Filetype clojure nmap <buffer> <leader>su :lua require ("trex").fts.clojure.switch_to_user_ns()<CR>
-autocmd Filetype clojure nmap <buffer> <leader>ss :lua require ("trex").fts.clojure.lein_send()<CR>
-autocmd Filetype clojure nmap <buffer> <leader>st :lua require ("trex").fts.clojure.test_current_file()<CR>
+autocmd Filetype clojure nmap <buffer> <leader>so :lua require ("trex").fts.clojure.fn.require_ns()<CR>
+autocmd Filetype clojure nmap <buffer> <leader>si :lua require ("trex").fts.clojure.fn.lein_import()<CR>
+autocmd Filetype clojure nmap <buffer> <leader>sr :lua require ("trex").fts.clojure.fn.lein_require_current_file()<CR>
+autocmd Filetype clojure nmap <buffer> <leader>sn :lua require ("trex").fts.clojure.fn.switch_ns()<CR>
+autocmd Filetype clojure nmap <buffer> <leader>su :lua require ("trex").fts.clojure.fn.switch_to_user_ns()<CR>
+autocmd Filetype clojure nmap <buffer> <leader>ss :lua require ("trex").fts.clojure.fn.lein_send()<CR>
+autocmd Filetype clojure nmap <buffer> <leader>st :lua require ("trex").fts.clojure.fn.test_current_file()<CR>
 
-autocmd Filetype clojure vnoremap <buffer> <leader>sv :lua require ("trex").fts.clojure.lein_send_visual()<CR>
+autocmd Filetype clojure vnoremap <buffer> <leader>sv :lua require ("trex").fts.clojure.fn.lein_send_visual()<CR>


### PR DESCRIPTION
Whenever I do a fresh install of trex and try to use it with clojure I get an error that the shortcuts result in lua fn call failures. This seems to fix it. Given the `TODO` above you have a cleaner solution in mind, but figured a quick patch would be nice :)